### PR TITLE
feat!: refactor code to work with JSON instead of CSV + refine score_filter to allow multiple scores

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,20 @@
 use clap::{command, Parser, ValueEnum};
+use serde::{Deserialize, Serialize};
 use std::{ops::RangeInclusive, path::PathBuf};
 
-use crate::utils::parse_range;
+use crate::utils::{parse_range, parse_score_filters};
+
+// pub type ScoreFilter = (String, RangeInclusive<usize>, Option<bool>);
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ScoreFilter {
+    /// Name of the score filter
+    pub name: String,
+    /// Range of allowed values
+    pub range: RangeInclusive<usize>,
+    /// If true, images that do not specify a score values for this filter will be matched. Default is: false
+    pub allow_unscored: bool,
+}
 
 #[derive(Debug, Parser)]
 #[command(name = "kanumi")]
@@ -23,9 +36,9 @@ pub struct Cli {
     #[arg(short, long = "metadata-file")]
     pub metadata_path: Option<PathBuf>,
 
-    /// Only show images with score contained within this range
-    #[arg(short = 's', long = "score", value_parser = parse_range)]
-    pub score_range: Option<RangeInclusive<usize>>,
+    /// Only show images with scores that match a specific range
+    #[arg(short = 's', long = "scores", value_parser = parse_score_filters)]
+    pub score_filters: Option<Vec<ScoreFilter>>,
 
     /// Only show images with a width contained within this range
     #[arg(short = 'W', long = "width", value_parser = parse_range)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,14 +4,7 @@ use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use std::{ops::RangeInclusive, path::PathBuf};
 
-#[derive(Debug, Deserialize)]
-pub struct ImageMeta {
-    #[serde(rename = "image_path")]
-    pub path: PathBuf,
-
-    #[serde(rename = "score")]
-    pub score: u8,
-}
+use crate::cli::ScoreFilter;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Configuration {
@@ -21,8 +14,8 @@ pub struct Configuration {
     #[serde(rename = "meta_path")]
     pub metadata_path: Option<PathBuf>,
 
-    #[serde(rename = "score")]
-    pub score_range: Option<RangeInclusive<usize>>,
+    #[serde(rename = "scores")]
+    pub score_filters: Option<Vec<ScoreFilter>>,
 
     #[serde(rename = "width")]
     pub width_range: Option<RangeInclusive<usize>>,
@@ -47,7 +40,7 @@ impl Configuration {
         Configuration {
             root_images_dir: default_root_dir,
             metadata_path: default_meta_path,
-            score_range: Some(RangeInclusive::new(0, 10)),
+            score_filters: None,
             width_range: Some(RangeInclusive::new(0, 10_000)),
             height_range: Some(RangeInclusive::new(0, 10_000)),
         }

--- a/src/image_meta.rs
+++ b/src/image_meta.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+type UUID = String;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ColorTheme {
+    #[serde(rename = "light")]
+    Light,
+    #[serde(rename = "dark")]
+    Dark,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum Color {
+    #[serde(rename = "red")]
+    Red,
+    #[serde(rename = "green")]
+    Green,
+    #[serde(rename = "blue")]
+    Blue,
+    #[serde(rename = "darkgray")]
+    DarkGray,
+    #[serde(rename = "black")]
+    Black,
+    #[serde(rename = "white")]
+    White,
+    #[serde(rename = "orange")]
+    Orange,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageMeta {
+    pub id: UUID,
+    pub path: PathBuf,
+    pub title: String,
+    pub description: String,
+    pub width: u32,
+    pub height: u32,
+    pub scores: Vec<ImageScore>,
+    pub tags: Vec<String>,
+    pub theme: ColorTheme,
+    pub colors: Vec<Color>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageScore {
+    pub name: String,
+    pub value: u8,
+}


### PR DESCRIPTION
- fix bug with `KANUMI_CONFIG` env var
- refactor to work with JSON instead of CSV
- `score` arg is now `scores` and supports multiple score ranges